### PR TITLE
Validate two-digit numeric IDs for button mapping

### DIFF
--- a/r36s-fn-select-fix.sh
+++ b/r36s-fn-select-fix.sh
@@ -51,9 +51,30 @@ CLEAN_OVERRIDES=0
 # ------------- Parse CLI flags -------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --fn-id)         FN_ID="${2:-}"; shift 2;;
-    --select-id)     SELECT_ID="${2:-}"; shift 2;;
-    --menu-id)       MENU_ID="${2:-}"; shift 2;;
+      --fn-id)
+        if [[ -z ${2-} || ! $2 =~ ^[0-9]{1,2}$ ]]; then
+          echo "--fn-id requires a numeric argument of up to two digits" >&2
+          exit 1
+        fi
+        FN_ID="$2"
+        shift 2
+        ;;
+      --select-id)
+        if [[ -z ${2-} || ! $2 =~ ^[0-9]{1,2}$ ]]; then
+          echo "--select-id requires a numeric argument of up to two digits" >&2
+          exit 1
+        fi
+        SELECT_ID="$2"
+        shift 2
+        ;;
+      --menu-id)
+        if [[ -z ${2-} || ! $2 =~ ^[0-9]{1,2}$ ]]; then
+          echo "--menu-id requires a numeric argument of up to two digits" >&2
+          exit 1
+        fi
+        MENU_ID="$2"
+        shift 2
+        ;;
     --clean-overrides) CLEAN_OVERRIDES=1; shift;;
     -h|--help)
       cat <<USAGE


### PR DESCRIPTION
## Summary
- validate that --fn-id, --select-id and --menu-id receive numeric arguments with at most two digits
- ensure script ends with a newline for clean output

## Testing
- `bash -n r36s-fn-select-fix.sh`
- `shellcheck r36s-fn-select-fix.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y shellcheck` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689cf6ffcbd48324ab1ddf223cbd51fd

## Summary by Sourcery

Validate that --fn-id, --select-id, and --menu-id flags only accept one- or two-digit numeric arguments and exit with an error on invalid input, and ensure the script ends with a trailing newline for clean output.

Enhancements:
- Add regex-based validation for --fn-id to require a one- or two-digit numeric argument
- Add regex-based validation for --select-id to require a one- or two-digit numeric argument
- Add regex-based validation for --menu-id to require a one- or two-digit numeric argument
- Append a newline at the end of the script to maintain clean output